### PR TITLE
Add simple autoreload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Typically you want to start with a `code.py` that you can later copy to your har
 The keys of the PewPew can be emulated by the arrow keys and `x` and `z`.
 
 The emulator does not support brightness.
+
+If you want to have the autoreload-on-save functionality of the 
+physical device you can run `autoloader.py`. It will watch the file 
+`code.py` in the current folder and restart the process if the file 
+is saved. `autoloader.py` will accept a filename as a  
+command-line-argument, in case you want to watch and execute some  
+other file.

--- a/autoloader.py
+++ b/autoloader.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+import sys
+import time
+
+os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
+
+WATCHED_FILE = sys.argv[1] if len(sys.argv)>1 else "code.py"
+REFRESH_CYCLE = 0.2
+
+previous = 0
+process = None
+
+if not os.path.isfile(WATCHED_FILE):
+    print(f"Error: {WATCHED_FILE} not found!")
+    sys.exit(0)
+
+try:
+    while True:
+        modified = os.stat(WATCHED_FILE).st_mtime
+        if modified > previous:
+            now = time.strftime("%H:%M:%S", time.localtime())
+            print(f"{now} - {WATCHED_FILE} was modified - reloading!")
+            previous = modified
+            if process:
+                process.kill()
+
+            process = subprocess.Popen(["python", WATCHED_FILE], shell=False)
+        
+        time.sleep(REFRESH_CYCLE)
+
+except KeyboardInterrupt:
+    if process:
+        process.kill()
+    print("\nCTRL-C detected, autoloader stopped.")


### PR DESCRIPTION
Part 2: Inspired by a talk about auto-reloaders today this was the missing piece for the pewpew emulator to be a good alternative for the instructor/teacher. 

Running `python autoloader.py` will look for a code.py file in the current directory, watch it and start/kill the process running this file anytime something is changed (saved), closely emulating the actual device experience much closer. This way hopefully using a larger display screen for the instructor with automatic updates on save will make using the emulator in class feasible, enabling an even better teaching & workshop-experience. `autoloader` will take 1 command-line argument (filename to watch) so `python autoloader.py europython.py` would watch and run `europython.py`. 

This is not as professional as it could be and error-handling is at a minimum, but it gets the job done and it was supposed to be "just for fun" ;-)